### PR TITLE
Add `Send + Sync` bounds to `StorableSession`

### DIFF
--- a/src/atproto.rs
+++ b/src/atproto.rs
@@ -56,7 +56,7 @@ impl From<RefreshUserSession> for UserSession {
         }
     }
 }
-pub trait StorableSession: Storage<UserSession, Error = BiskyError> {}
+pub trait StorableSession: Storage<UserSession, Error = BiskyError> + Send + Sync {}
 
 #[derive(Clone, Builder)]
 pub struct Client {


### PR DESCRIPTION
This is necessary for `Client` to implement `Send`, and thus be usable inside e.g. `tokio::spawn`.

Closes jesopo/bisky#4.