### PR TITLE
Disable default features of `reqwest` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { version = "0.4.24", features = ["serde"] }
 derive_builder = "0.12.0"
 miette = "5.8.0"
 parking_lot = "0.12.1"
-reqwest = { version = "0.11.16", features = ["json", "rustls"] }
+reqwest = { version = "0.11.16", default-features = false, features = ["json"] }
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 thiserror = "1.0.40"


### PR DESCRIPTION
This enables downstream users of this library to choose their TLS backend. The `rustls` feature flag was not enabling `rustls` usage; that is done with the `rustls-tls` feature flag.